### PR TITLE
fix: Correct React app asset paths and ensure build

### DIFF
--- a/views/chat.ejs
+++ b/views/chat.ejs
@@ -8,6 +8,6 @@
 </head>
 <body>
     <div id="root"></div>
-    <script type="module" src="/assets/index-BcpAdznK.js"></script>
+    <script type="module" src="/assets/index-Cv9reEf-.js"></script>
 </body>
 </html>


### PR DESCRIPTION
I've corrected an issue where the React chat application's CSS and JavaScript assets were not loading correctly, leading to 404 errors and MIME type mismatches.

Here's what I did:
- Ensured the Vite React application in `public/chat-app` is rebuilt.
- Updated asset paths (specifically the hashed JavaScript filename) in `views/chat.ejs` to match the latest build output.
- Verified that the Express static file serving configuration in `index.js` (`app.use(express.static('public/chat-app/dist'))`) correctly serves the assets from the `public/chat-app/dist` directory.

This should resolve the issues you were seeing with loading the chat interface on `/chatpage`.